### PR TITLE
Reolved the app screenshot coming in foreground in ecosystem 

### DIFF
--- a/components/HomePage/NeptuneEcosystem/style.module.css
+++ b/components/HomePage/NeptuneEcosystem/style.module.css
@@ -28,6 +28,7 @@
 
 .top-left-img {
   @apply hidden absolute top-0 left-0;
+  z-index: -1;
 }
 
 @media (min-width: 1024px) {
@@ -38,6 +39,7 @@
 
 .bottom-left-img {
   @apply absolute w-52 top-16 right-0;
+   z-index: -1;
 }
 
 @media (min-width: 640px) {
@@ -60,6 +62,7 @@
 
 .bottom-left-img2 {
   @apply hidden absolute;
+   z-index: -1;
 }
 
 @media (min-width: 1024px) {


### PR DESCRIPTION
This PR is related to [this ](https://app.clickup.com/t/21v41pj)clickup ticket. As seen in the screenshot the app screenshot image is now in background


![image](https://user-images.githubusercontent.com/99203362/153803880-b10a008c-e82a-4dd2-b9ab-127e3238d42a.png)


