### PR TITLE
Fixed Robots

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -22,12 +22,3 @@ Allow: /pressroom/*
 
 User-agent: *
 Allow: /
-Allow: /blog/*
-Allow: /pressroom/*
-Disallow: /blog/search/*
-Disallow: /blog/tag/*
-Disallow: /blog/page/*
-Disallow: /pressroom/tag/*
-Disallow: /pressroom/page/*
-Disallow: /policies/*
-Disallow: /videos/*


### PR DESCRIPTION
Dropped the `Disallow` rule because according to Google

> Important: For the noindex rule to be effective, the page or resource must not be blocked by a robots.txt file, and it has to be otherwise accessible to the crawler. If the page is blocked by a robots.txt file or the crawler can't access the page, the crawler will never see the noindex rule, and the page can still appear in search results, for example if other pages link to it.
