### PR TITLE
Set chain property on hack-database to be nullable

### DIFF
--- a/src/scripts/hack-database/table/renderers.ts
+++ b/src/scripts/hack-database/table/renderers.ts
@@ -10,8 +10,8 @@ const renderers: Record<string, (hack: Hack) => string> = {
   'Amount Lost': (hack: Hack) => hack.amountLost,
   Chains: (hack: Hack) => `
   <div class="chain icon group">
-    ${hack.chains.length === 0 ? '-' : ''}
-    ${hack.chains.map((chain) =>
+    ${(hack.chains ?? []).length === 0 ? '-' : ''}
+    ${(hack.chains ?? []).map((chain) =>
     availableChainIcons.includes(chain.shortName)
       ? (
         `<i class="${chain.shortName.toLowerCase() + ' chain icon'}" title="${chain.title}"></i>`

--- a/src/views/hack-database/HackTable.astro
+++ b/src/views/hack-database/HackTable.astro
@@ -23,7 +23,7 @@ const renderers: Record<string, (hack: Hack) => string> = {
     }),
   "Amount Lost": (hack: Hack) => hack.amountLost,
   Chains: (hack: Hack) =>
-    hack.chains
+    (hack.chains ?? [])
       .map((chain) =>
         availableChainIcons.includes(chain.shortName)
           ? `<i class="${

--- a/types/api.d.ts
+++ b/types/api.d.ts
@@ -268,7 +268,7 @@ interface Hack {
   name: string
   date: Date
   amountLost: string
-  chains: Chain[]
+  chains?: Chain[]
   techniques: string
   description?: string
   link: string


### PR DESCRIPTION
## Changes
- Made the `chains` property on Hack interface nullable
- Used empty array as fallback for null or undefined wherever used