### PR TITLE
Fix: Color on mobile page in blocksec report when plugin not found

### DIFF
--- a/src/design-system/_colors.scss
+++ b/src/design-system/_colors.scss
@@ -1,5 +1,6 @@
 $white: #fafafa;
 $black: #121212;
+$base-black: #000000;
 $base-white: #ffffff;
 
 $black-800: #171717;

--- a/src/views/about/Roadmap.scss
+++ b/src/views/about/Roadmap.scss
@@ -270,8 +270,8 @@
       backdrop-filter: blurs.$sm;
       border-radius: 50%;
 
-      background-color: colors.$white;
-      color: colors.$gray-500;
+      background-color: colors.$base-white;
+      color: colors.$base-black;
       border: 1px solid colors.$gray-200;
 
 
@@ -383,7 +383,7 @@
   .arrows {
     button {
       background-color: colors.$gray-700;
-      color: colors.$gray-50;
+      color: colors.$base-white;
       border: 1px solid colors.$gray-800;
 
       &:not(:disabled):not([data-disabled]):hover {

--- a/src/views/security-detail/PDFViewer.scss
+++ b/src/views/security-detail/PDFViewer.scss
@@ -22,7 +22,6 @@
     max-width: 768px;
     margin-left: auto;
     margin-right: auto;
-
     height: 90vh;
     min-height: 600px;
   }
@@ -31,6 +30,7 @@
     max-width: 768px;
     margin-left: auto;
     margin-right: auto;
+    color: colors.$base-white;
 
     h2 {
       @include styles.display-md;


### PR DESCRIPTION
## Changes
- Change text color to white when pdf plugin is not found on browser.
- Fixed arrow color on roadmap