### PR TITLE
Fixed copy button position in scrolling code snippets

### DIFF
--- a/src/elements/content/Content.scss
+++ b/src/elements/content/Content.scss
@@ -58,6 +58,10 @@
     }
   }
 
+  .pre.wrapper {
+    position: relative;
+  }
+
   pre {
     font-family: Consolas, Monaco, monospace;
     max-width: 100%;
@@ -68,7 +72,6 @@
     border: 1px solid light.$hljs-border-color;
     padding: 1em 0;
     border-radius: 18px;
-    position: relative;
 
     code {
       animation: 500ms ease-out 0s 1 fadeIn;

--- a/src/scripts/utils/setup-hljs.js
+++ b/src/scripts/utils/setup-hljs.js
@@ -34,10 +34,24 @@ const addCopyButtons = () => {
   }
 }
 
+const wrapAllCodeSnippets = () => {
+  const snippets = document.getElementsByTagName('pre')
+  const numberOfSnippets = snippets.length
+
+  for (let i = 0; i < numberOfSnippets; i++) {
+    const toWrap = snippets[i]
+    const wrapper = document.createElement('div')
+    wrapper.classList.add('pre', 'wrapper')
+    toWrap.parentNode.insertBefore(wrapper, toWrap)
+    wrapper.appendChild(toWrap)
+  }
+}
+
 export const setupHighlightJS = async function () {
   hljsDefineSolidity(hljs)
   hljs.highlightAll()
   window.hljs = hljs
+  wrapAllCodeSnippets()
   addCopyButtons()
   await highlightLineNumbersLoad()
   hljs.initLineNumbersOnLoad()


### PR DESCRIPTION
## Problem
- When a code snippet that overflew the viewport was scrolled, the position of the copy button (top right) was not correct.

## Solution 
- Added a wrapper element to the pre-tags, and absolutely positioned the copy button based on that.