### PR TITLE
remove image invert in dark mode

### DIFF
--- a/src/components/RichTextContent.scss
+++ b/src/components/RichTextContent.scss
@@ -736,10 +736,6 @@
     color: colors.$gray-25;
   }
 
-  img {
-    filter: invert(100%);
-  }
-
   figure:has(figcaption) {
     border: 1px dashed colors.$gray-600;
 


### PR DESCRIPTION
blog and docs: removed `invert` filter in dark mode from images